### PR TITLE
Update webpack peerDep to include ^3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "object.assign": "^4.0.4"
   },
   "peerDependencies": {
-    "webpack": "^2.2.1"
+    "webpack": "^2.2.1 || ^3.0.0"
   },
   "devDependencies": {
     "babel-eslint": "^7.1.1",


### PR DESCRIPTION
Resolves peer dep warning when using Webpack 3.0+